### PR TITLE
correct name for app management

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <info>
 	<id>tasks_enhanced</id>
-	<name>tasks_enhanced</name>
+	<name>Tasks</name>
 	<version>0.2.1</version>
 	<licence>AGPL</licence>
 	<author>Raimund Schlüßler</author>


### PR DESCRIPTION
The name in the sidebar and the title of the apps management was shown as an ugly »tasks_enhanced«. This changes it to the proper »Tasks«.

@raimund-schluessler
