### PR TITLE
Changed package.json version to semver syntax

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "task",
   "description": "ownCloud Task App",
-  "version": "0.1",
+  "version": "0.1.0",
   "author": {
     "name": "Raimund Schlüßler",
     "email": "raimund.schluessler@googlemail.com"

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "task",
   "description": "ownCloud Task App",
-  "version": "0.1.0",
+  "version": "0.5.1",
   "author": {
     "name": "Raimund Schlüßler",
     "email": "raimund.schluessler@googlemail.com"


### PR DESCRIPTION
The version number of the package.json has to match the semver syntax as described at https://docs.npmjs.com/files/package.json#version.
Otherwise npm install refuses to parse the file and install the dependencies.