### PR TITLE
fix creation of first comment

### DIFF
--- a/controller/taskscontroller.php
+++ b/controller/taskscontroller.php
@@ -558,12 +558,17 @@ class TasksController extends Controller {
 			$vcalendar = \OC_Calendar_App::getVCalendar($taskId);
 			$vtodo = $vcalendar->VTODO;
 
-			// Determine new commentId by looping through all comments
-			$commentIds = array();
-			foreach($vtodo->COMMENT as $com) {
-				$commentIds[] = (int)$com['X-OC-ID']->getValue();
+			if($vtodo->COMMENT == "") {
+				// if this is the first comment set the id to 0
+				$commentId = 0;
+			} else {
+				// Determine new commentId by looping through all comments
+				$commentIds = array();
+				foreach($vtodo->COMMENT as $com) {
+					$commentIds[] = (int)$com['X-OC-ID']->getValue();
+				}
+				$commentId = 1+max($commentIds);
 			}
-			$commentId = 1+max($commentIds);
 
 			$now = 	new \DateTime();
 			$vtodo->add('COMMENT',$comment,


### PR DESCRIPTION
Adding the first comment to a task results in the following two errors:
```
{"reqId":"wTsUh7fS9T4Db5qJ4H9c","remoteAddr":"127.0.0.1","app":"PHP","message":"Invalid argument supplied for foreach() at \/...\/owncloud\/local\/apps\/tasks\/controller\/taskscontroller.php#563","level":3,"time":"2015-05-18T10:49:26+00:00"}
{"reqId":"wTsUh7fS9T4Db5qJ4H9c","remoteAddr":"127.0.0.1","app":"PHP","message":"max(): Array must contain at least one element at \/...\/owncloud\/local\/apps\/tasks\/controller\/taskscontroller.php#566","level":3,"time":"2015-05-18T10:49:26+00:00"}
```