### PR TITLE
Clean-up of dev pipeline (grunt)

### DIFF
--- a/js/Gruntfile.coffee
+++ b/js/Gruntfile.coffee
@@ -28,9 +28,10 @@ module.exports = (grunt) ->
 	grunt.loadNpmTasks('grunt-contrib-coffee')
 	grunt.loadNpmTasks('grunt-contrib-less')
 	grunt.loadNpmTasks('grunt-coffeelint')
-	grunt.loadNpmTasks('grunt-wrap');
-	grunt.loadNpmTasks('grunt-phpunit');
-	grunt.loadNpmTasks('grunt-karma');
+	grunt.loadNpmTasks('grunt-wrap')
+	grunt.loadNpmTasks('grunt-phpunit')
+	grunt.loadNpmTasks('grunt-karma')
+	grunt.loadNpmTasks('grunt-concurrent')
 
 	grunt.initConfig
 
@@ -67,7 +68,7 @@ module.exports = (grunt) ->
 				ext: ".css"
 
 		concat:
-			app:
+			default:
 				options:
 					banner: '<%= meta.banner %>\n'
 					stripBanners:
@@ -81,7 +82,7 @@ module.exports = (grunt) ->
 					]
 				dest: '<%= meta.production %>app.js'
 		wrap:
-			app:
+			default:
 				src: '<%= meta.production %>app.js'
 				dest: ''
 				wrapper: [
@@ -90,7 +91,7 @@ module.exports = (grunt) ->
 				]
 
 		coffeelint:
-			app: [
+			default: [
 				'app/**/*.coffee'
 				'tests/**/*.coffee'
 			]
@@ -107,15 +108,21 @@ module.exports = (grunt) ->
 			coffeescript:
 				files: ['app/**/*.coffee']
 				tasks: 'coffee'
-			concat:
-				files: [
-					'<%= meta.build %>app/**/*.js'
-					'<%= meta.build %>tests/**/*.js'
-				]
-				tasks: 'compile'
-			less:
+			js:
+				files: ['app/**/*.js']
+				tasks: 'js'
+			css:
 				files: ['../css/*.less']
-				tasks: 'less'
+				tasks: 'css'
+
+		concurrent:
+			dev:
+				tasks: [
+					'watch:js'
+					'watch:css'
+				]
+				options:
+					logConcurrentOutput: true
 
 		karma:
 			unit:
@@ -139,8 +146,13 @@ module.exports = (grunt) ->
 				colors: true
 
 
-	grunt.registerTask('run', ['watch:concat'])
-	grunt.registerTask('compile', ['concat', 'wrap', 'coffeelint'])
 	grunt.registerTask('ci', ['karma:continuous'])
-	grunt.registerTask('testphp', ['watch:phpunit'])
-	# grunt.registerTask('default', 'watch')
+
+	grunt.registerTask('js', ['coffeelint', 'coffee', 'concat', 'wrap'])
+	grunt.registerTask('css', ['less'])
+
+	grunt.registerTask('dev', ['js', 'css'])
+
+	# overwrite watch:all to simplify naming
+	grunt.registerTask('watch:dev', ['concurrent:dev'])
+	grunt.registerTask('default', 'dev')

--- a/js/Gruntfile.coffee
+++ b/js/Gruntfile.coffee
@@ -32,6 +32,7 @@ module.exports = (grunt) ->
 	grunt.loadNpmTasks('grunt-phpunit')
 	grunt.loadNpmTasks('grunt-karma')
 	grunt.loadNpmTasks('grunt-concurrent')
+	grunt.loadNpmTasks('grunt-newer')
 
 	grunt.initConfig
 
@@ -145,8 +146,8 @@ module.exports = (grunt) ->
 
 	grunt.registerTask('ci', ['karma:continuous'])
 
-	grunt.registerTask('js', ['coffeelint', 'coffee', 'concat', 'wrap'])
-	grunt.registerTask('css', ['less'])
+	grunt.registerTask('js', ['newer:coffeelint', 'newer:coffee', 'concat', 'wrap'])
+	grunt.registerTask('css', ['newer:less'])
 
 	grunt.registerTask('dev', ['js', 'css'])
 

--- a/js/Gruntfile.coffee
+++ b/js/Gruntfile.coffee
@@ -105,11 +105,8 @@ module.exports = (grunt) ->
 
 
 		watch:
-			coffeescript:
-				files: ['app/**/*.coffee']
-				tasks: 'coffee'
 			js:
-				files: ['app/**/*.js']
+				files: ['app/**/*.coffee']
 				tasks: 'js'
 			css:
 				files: ['../css/*.less']

--- a/js/package.json
+++ b/js/package.json
@@ -28,7 +28,8 @@
     "phantomjs": "~1.8.1-3",
     "grunt-phpunit": "0.2.0",
     "grunt-karma": "~0.4.5",
-    "grunt-concurrent": "~1.0.0"
+    "grunt-concurrent": "~1.0.0",
+    "grunt-newer": "~1.1.1"
   },
   "engine": "node >= 0.8"
 }

--- a/js/package.json
+++ b/js/package.json
@@ -27,8 +27,8 @@
     "grunt-wrap": "~0.2.0",
     "phantomjs": "~1.8.1-3",
     "grunt-phpunit": "0.2.0",
-    "gruntacular": "~0.3.0",
-    "grunt-karma": "~0.4.5"
+    "grunt-karma": "~0.4.5",
+    "grunt-concurrent": "~1.0.0"
   },
   "engine": "node >= 0.8"
 }


### PR DESCRIPTION
I cleaned up the Gruntfile to remove some broken grunt-tasks and simplify the remaining tasks.

The changes offer the following commands:
* `grunt` - the default task checks the coffeescript, compiles, concats and wraps it. Furthermore the less stylesheets are compiled to css (aliases `grunt default` and `grunt dev`)
* `grunt js` & `grunt css` - splits up the previous command
* `grunt watch:dev` - similar to the `grunt` command but *watches* (concurrently) for changes in the coffeescript and stylesheets
* `grunt watch:js` & `grunt watch:css` - watches for changes in the coffeescript files or less files respectively

Additionally there are tasks to test the javascript and php (`grunt ci` & `grunt phpunit`).

Some changes I am thinking about and would like to have feedback on:
* Removing the test-tasks as there are currently no tests for php or javascript
* Moving the Gruntfile into the root folder of the project as it doesn't only compile javascript but also css.
* Adding [autoprefixer](https://github.com/postcss/autoprefixer) to the pipeline

I will also add a documentation on the grunt commands later on.