### PR TITLE
Fix search

### DIFF
--- a/js/app/services/businesslayer/searchbusinesslayer.coffee
+++ b/js/app/services/businesslayer/searchbusinesslayer.coffee
@@ -36,9 +36,9 @@ $routeParams, $location) ->
 
 		attach: (search) =>
 			search.setFilter('tasks', (query) =>
-				@_$rootScope.$apply(
+				@_$rootScope.$apply( () =>
 					@setFilter(query)
-					)
+				)
 			)
 			search.setRenderer('task', @renderTaskResult.bind(@))
 			search.setHandler('task',  @handleTaskClick.bind(@))

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -1391,7 +1391,9 @@
         SearchBusinessLayer.prototype.attach = function(search) {
           var _this = this;
           search.setFilter('tasks', function(query) {
-            return _this._$rootScope.$apply(_this.setFilter(query));
+            return _this._$rootScope.$apply(function() {
+              return _this.setFilter(query);
+            });
           });
           search.setRenderer('task', this.renderTaskResult.bind(this));
           return search.setHandler('task', this.handleTaskClick.bind(this));


### PR DESCRIPTION
Closes #246

Searching for a task with a string containing a whitespace throws a javascript error on some installations. I don't know why this doesn't throw an error on every version, but the PR is fixing the error on every system.