### PR TITLE
Add phpdocumentor task to grunt

### DIFF
--- a/js/Gruntfile.coffee
+++ b/js/Gruntfile.coffee
@@ -31,6 +31,7 @@ module.exports = (grunt) ->
 	grunt.loadNpmTasks('grunt-phpunit')
 	grunt.loadNpmTasks('grunt-karma')
 	grunt.loadNpmTasks('grunt-newer')
+	grunt.loadNpmTasks('grunt-phpdocumentor')
 
 	grunt.initConfig
 
@@ -120,6 +121,12 @@ module.exports = (grunt) ->
 				dir: '../tests'
 			options:
 				colors: true
+
+		phpdocumentor:
+			default:
+				options:
+					directory : '../appinfo,../db,../controllers,../service'
+					target : '../docs'
 
 
 	grunt.registerTask('ci', ['karma:continuous'])

--- a/js/package.json
+++ b/js/package.json
@@ -16,20 +16,21 @@
   "contributors": [],
   "dependencies": {},
   "devDependencies": {
+    "coffee-script": "~1.4.0",
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.6",
-    "coffee-script": "~1.4.0",
-    "grunt-contrib-coffee": "~0.7.0",
-    "grunt-contrib-less": "~0.6.4",
-    "grunt-contrib-concat": "~0.1.2",
-    "grunt-contrib-watch": "~0.2.0",
     "grunt-coffeelint": "0.0.6",
-    "grunt-wrap": "~0.2.0",
-    "phantomjs": "~1.8.1-3",
-    "grunt-phpunit": "0.2.0",
-    "grunt-karma": "~0.4.5",
     "grunt-concurrent": "~1.0.0",
-    "grunt-newer": "~1.1.1"
+    "grunt-contrib-coffee": "~0.7.0",
+    "grunt-contrib-concat": "~0.1.2",
+    "grunt-contrib-less": "~0.6.4",
+    "grunt-contrib-watch": "~0.2.0",
+    "grunt-karma": "~0.4.5",
+    "grunt-newer": "~1.1.1",
+    "grunt-phpdocumentor": "^0.4.1",
+    "grunt-phpunit": "0.2.0",
+    "grunt-wrap": "~0.2.0",
+    "phantomjs": "~1.8.1-3"
   },
   "engine": "node >= 0.8"
 }


### PR DESCRIPTION
This pull request adds a task to grunt which generates a php documentation of the project.

@raimund-schluessler what do you think of this addition?
Should we add the documentation itself as well or should we even serve it via gh-pages?