### PR TITLE
Fixing and Harmonizing Sorting of Tasks

### DIFF
--- a/templates/part.collectionall.php
+++ b/templates/part.collectionall.php
@@ -14,7 +14,7 @@
             <li class="task-item ui-draggable handler"
                 taskID="{{task.uri}}"
                 ng-animate="'animate'"
-                ng-repeat="task in filtered = filteredTasks() | filter:hasNoParent(task) | filter:filterTasks(task,calendar.uri) | filter:filterTasks(task,route.collectionID) | orderBy:sortDue | orderBy:'priority':true | orderBy:'completed_date':true"
+                ng-repeat="task in filtered = filteredTasks() | filter:hasNoParent(task) | filter:filterTasks(task,calendar.uri) | filter:filterTasks(task,route.collectionID) | orderBy:[sortDue,'-priority','-completed','start','summary']"
                 ng-click="openDetails(task.uri,$event)"
                 ng-class="{done: task.completed}"
                 dnd-draggable="task"

--- a/templates/part.collectionweek.php
+++ b/templates/part.collectionweek.php
@@ -13,7 +13,7 @@
             <li class="task-item ui-draggable handler"
                 taskID="{{task.uri}}"
                 ng-animate="'animate'"
-                ng-repeat="task in filtered = filteredTasks() | filter:taskAtDay(task,day) | filter:hasNoParent(task) | filter:{'completed':'false'} | orderBy:sortDue | orderBy:'priority':true"
+                ng-repeat="task in filtered = filteredTasks() | filter:taskAtDay(task,day) | filter:hasNoParent(task) | filter:{'completed':'false'} | orderBy:[sortDue,'-priority','-completed','start','summary']"
                 ng-click="openDetails(task.uri,$event)"
                 ng-class="{done: task.completed}"
                 dnd-draggable="task"

--- a/templates/part.taskbody.php
+++ b/templates/part.taskbody.php
@@ -49,7 +49,7 @@
         </li>
         <li taskID="{{ task.uri }}"
             class="task-item ui-draggable handler subtask"
-            ng-repeat="task in getSubTasks(filtered,task) | orderBy:'1*id':true | orderBy:'priority':true | orderBy:'completed':false"
+            ng-repeat="task in getSubTasks(filtered,task) | orderBy:[sortDue,'-priority','-completed','start','summary']"
             ng-click="openDetails(task.uri,$event)"
             ng-class="{done: task.completed}"
             ng-include="'part.taskbody'"

--- a/templates/part.tasklist.php
+++ b/templates/part.tasklist.php
@@ -11,7 +11,7 @@
             dnd-dragover="dragover(event, index)">
             <li class="task-item ui-draggable handler"
                 taskID="{{ task.uri }}"
-                ng-repeat="task in filtered = filteredTasks() | filter:hasNoParent(task) | filter:filterTasks(task,route.calendarID) | filter:{'completed':'false'} | orderBy:'1*id':true | orderBy:sortDue | orderBy:'priority':true"
+                ng-repeat="task in filtered = filteredTasks() | filter:hasNoParent(task) | filter:filterTasks(task,route.calendarID) | filter:{'completed':'false'} | orderBy:[sortDue,'-priority','-completed','start','summary']"
                 ng-click="openDetails(task.uri,$event)"
                 ng-class="{done: task.completed}"
                 dnd-draggable="task"


### PR DESCRIPTION
Sorting of tasks is used at four places:
- list of all tasks (`part.collectionall.php`)
- list of tasks for a specific day (`part.collectionweek.php`)
- list of tasks for a specific calendar (`part.tasklist.php`)
- list of subtasks (`part.taskbody.php`)

Currently, all these lists make use of sorting the tasks using multiple attributes. However, there are two issues:

**1. The use of `orderBy` (AngularJS) is not correct**
Currently, multiple attributes are applied by using multiple `orderBy` filters, e.g. `... | orderBy:sortDue | orderBy:'priority':true`. However, this syntax is not correct and leads to undesired results. Instead, multiple attributes have to be applied using a list: `orderBy: [sortDue,'-priority']`. See https://docs.angularjs.org/api/ng/filter/orderBy

**2. The used ordering attributes differ**
Currently, some attributes are only in some lists. However, in the UI, the lists are like filters for the user, so they should use the same attributes.

I've fixed these issues and added some new, low-priority attributes for sorting, if the other attributes are equal (i.e. `start` and `summary`)