### PR TITLE
Add confirmation directive

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -31,6 +31,9 @@ $application->registerRoutes($this, array('routes' => array(
 	// page
 	array('name' => 'page#index', 'url' => '/', 'verb' => 'GET'),
 
+	// templates
+	array('name' => 'page#templates', 'url' => '/templates/{template}', 'verb' => 'GET'),
+
 	// collections
 	array('name' => 'collections#getCollections',	'url' => '/collections',										'verb' => 'GET'),
 	array('name' => 'collections#setVisibility',	'url' => '/collection/{collectionID}/visibility/{visibility}',	'verb' => 'POST'),

--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -24,6 +24,7 @@ namespace OCA\Tasks\Controller;
 
 use \OCP\AppFramework\Controller;
 use \OCP\AppFramework\Http\TemplateResponse;
+use \OCP\AppFramework\Http\NotFoundResponse;
 use \OCP\IRequest;
 use \OCP\IConfig;
 
@@ -60,6 +61,21 @@ class PageController extends Controller {
 			'DOM' => $day
 		));
 
+		return $response;
+	}
+
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function templates($template) {
+		$templates = array(	'confirmation');
+		if (in_array($template, $templates)) {
+			$response = new TemplateResponse('tasks', $template, [], 'blank');
+		} else {
+			$response = new NotFoundResponse();
+		}
 		return $response;
 	}
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1567,3 +1567,58 @@ ol[dnd-list] .dndPlaceholder {
   border-color: #e9322d !important;
   box-shadow: 0 0 6px #f8b9b7;
 }
+
+.confirmed {
+  opacity: 1 !important;
+}
+.confirmed img {
+  margin-left: auto;
+  margin-right: auto !important;
+  display: block;
+}
+
+.confirmation-default {
+  overflow: hidden;
+}
+
+.confirmed .confirmation-default {
+  display: none !important;
+}
+
+.confirmation-confirm, .confirmation-abort {
+  width: 50% !important;
+  display: none !important;
+  overflow: hidden;
+  float: right;
+  height: 100% !important;
+}
+
+.confirmation-confirm, .confirmation-confirm span {
+  background-color: red;
+  cursor: default !important;
+}
+
+.confirmed .confirmation-confirm, .confirmed .confirmation-abort {
+  display: inline-block !important;
+}
+
+.confirmed .confirmation-confirm img {
+  display: none;
+}
+
+.countdown {
+  color: white;
+  display: block;
+  text-align: center;
+}
+
+.confirmed.active .confirmation-confirm{
+  cursor: pointer !important;
+}
+.confirmed.active .confirmation-confirm span.countdown {
+  display: none;
+}
+
+.confirmed.active .confirmation-confirm img {
+  display: block;
+}

--- a/js/app/controllers/listcontroller.js
+++ b/js/app/controllers/listcontroller.js
@@ -49,15 +49,15 @@ angular.module('Tasks').controller('ListController', [
 			this._$scope.nameError = false;
 			this._$scope.color = '#31CC7C';
 
+			this._$scope.deleteMessage = function (calendar) {
+				return t('tasks', 'This will delete the Calendar "%s" and all of its entries.').replace('%s', calendar.displayname);
+			};
+
 			this._$scope["delete"] = function(calendar) {
-				var really;
-				really = confirm(t('tasks', 'This will delete the Calendar "%s" and all of its entries.').replace('%s', calendar.displayname));
-				if (really) {
-					return _$listsbusinesslayer["delete"](calendar).then(function() {
-						$location.path('/calendars/' + _$listsmodel.getStandardList().uri);
-						return $scope.$apply();
-					});
-				}
+				return _$listsbusinesslayer["delete"](calendar).then(function() {
+					$location.path('/calendars/' + _$listsmodel.getStandardList().uri);
+					return $scope.$apply();
+				});
 			};
 
 			this._$scope.startCreate = function() {

--- a/js/app/directives/confirmation.js
+++ b/js/app/directives/confirmation.js
@@ -1,0 +1,96 @@
+/**
+ * ownCloud - Tasks
+ *
+ * @author Raimund Schlüßler
+ * @copyright 2016 Raimund Schlüßler <raimund.schluessler@googlemail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+angular.module('Tasks').directive('confirmation', function() {
+	'use strict';
+	return {
+		priority: -1,
+		restrict: 'A',
+		templateUrl: OC.generateUrl('/apps/tasks/templates/confirmation', {}),
+		scope: {
+			confirmationFunction: "&confirmation",
+			confirmationMessage: "&confirmationMessage",
+
+		},
+		controller: 'ConfirmationController'
+	};
+});
+
+angular.module('Tasks').controller('ConfirmationController', [
+	'$scope', '$rootScope', '$element', '$attrs', '$compile', '$document', '$window', '$timeout', function($scope, $rootScope, $element, $attrs, $compile, $document, $window, $timeout) {
+		'use strict';
+		var ConfirmationController = (function() {
+			function ConfirmationController(_$scope, $rootScope, $element, $attrs, $compile, $document, $window, $timeout) {
+				this._$scope = _$scope;
+				this._$scope.countdown = 3;
+
+				$element.bind( 'click', function( e ){
+					_$scope.countdown = 3;
+					$element.removeClass('active');
+					var message = _$scope.confirmationMessage() ? _$scope.confirmationMessage() : "Are you sure?";
+					if ($element.hasClass('confirmed')) {
+						return;
+					}
+					e.stopPropagation();
+					_$scope.activate();
+					$element.children('.confirmation-confirm')
+					.tooltip({title: message, container: 'body', placement: 'right'});
+					$element.addClass("confirmed");
+				});
+
+				$element.children('.confirmation-confirm').bind( 'click', function (e) {
+					if ($element.hasClass('confirmed active')) {
+						_$scope.confirmationFunction();
+						return;
+					} else{
+						e.stopPropagation();
+					}
+				});
+
+				this._$scope.documentClick = function () {
+					$element.removeClass("confirmed");
+				};
+
+				this._$scope.activate = function () {
+					if (_$scope.countdown) {
+						$element.find('.countdown').html(_$scope.countdown+' s');
+						$timeout(function() {
+							_$scope.activate();
+							}, 1000);
+						_$scope.countdown--;
+					} else {
+						$element.addClass('active');
+					}
+				};
+
+				$document.bind('click', _$scope.documentClick);
+				$document.bind('touchend', _$scope.documentClick);
+
+				$scope.$on('$destroy', function() {
+					$document.unbind('click', _$scope.documentClick);
+					$document.unbind('touchend', _$scope.documentClick);
+				});
+			}
+			return ConfirmationController;
+		})();
+		return new ConfirmationController($scope, $rootScope, $element, $attrs, $compile, $document, $window, $timeout);
+	}
+]);

--- a/templates/confirmation.php
+++ b/templates/confirmation.php
@@ -1,0 +1,11 @@
+<span class="confirmation-default" title="<?php p($l->t('Delete')); ?>">
+	<img class="icon-delete svg" src="<?php p(image_path('core', 'actions/delete.svg'))?>"/>
+	<span><?php p($l->t('Delete')); ?></span>
+</span>
+<span class="confirmation-confirm">
+    <span class="countdown">33 &nbsp;</span>
+    <img class="icon-delete svg" src="<?php p(image_path('core', 'actions/delete-white.svg'))?>"/>
+</span>
+<span class="confirmation-abort" title="<?php p($l->t('Cancel')); ?>">
+    <img class="icon-close svg" src="<?php p(image_path('core', 'actions/close.svg'))?>"/>
+</span>

--- a/templates/main.php
+++ b/templates/main.php
@@ -76,11 +76,7 @@
                                 <span><?php p($l->t('Export')); ?></span>
                             </a>
                         </li>
-                        <li>
-                            <span title="<?php p($l->t('Delete')); ?>" ng-click="delete(calendar)">
-                                <img class="icon-delete svg" src="<?php p(image_path('core', 'actions/delete.svg'))?>"/>
-                                <span><?php p($l->t('Delete')); ?></span>
-                            </span>
+                        <li confirmation="delete(calendar)" confirmation-message="deleteMessage(calendar)">
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
This PR add a confirmation dialog to the delete button of the calendar list to prevent accidental deletions. See this GIF for how it works:

![directive2](https://cloud.githubusercontent.com/assets/2496460/18019723/b88e765c-6bdd-11e6-9385-275aee406085.gif)


After a click on "delete" a menu with a cancel button and a delete button appears. The delete button is activated after three seconds. Also an explaining tooltip is shown when you hover over the delete button.