### PR TITLE
Allows setting DATE values for DTSTART and DUE

### DIFF
--- a/js/app/app.js
+++ b/js/app/app.js
@@ -76,6 +76,16 @@ angular.module('Tasks').run([
 				sameElse: '[' + t('tasks', 'Due on') + '] MMM DD, YYYY, HH:mm'
 			}
 		});
+ 		moment.locale('details_allday', {
+ 			calendar: {
+ 				lastDay: '[' + t('tasks', 'Due yesterday') + ']',
+ 				sameDay: '[' + t('tasks', 'Due today') + ']',
+ 				nextDay: '[' + t('tasks', 'Due tomorrow') + ']',
+ 				lastWeek: '[' + t('tasks', 'Due on') + '] MMM DD, YYYY',
+ 				nextWeek: '[' + t('tasks', 'Due on') + '] MMM DD, YYYY',
+ 				sameElse: '[' + t('tasks', 'Due on') + '] MMM DD, YYYY'
+ 			}
+ 		});
 		moment.locale('start', {
 			calendar: {
 				lastDay: '[' + t('tasks', 'Started yesterday') + '], HH:mm',
@@ -92,6 +102,22 @@ angular.module('Tasks').run([
 				}
 			}
 		});
+ 		moment.locale('start_allday', {
+ 			calendar: {
+ 				lastDay: '[' + t('tasks', 'Started yesterday') + ']',
+ 				sameDay: '[' + t('tasks', 'Starts today') + ']',
+ 				nextDay: '[' + t('tasks', 'Starts tomorrow') + ']',
+ 				lastWeek: '[' + t('tasks', 'Started on') + '] MMM DD, YYYY',
+ 				nextWeek: '[' + t('tasks', 'Starts on') + '] MMM DD, YYYY',
+ 				sameElse: function() {
+ 					if (this.diff(moment()) > 0) {
+ 						return '[' + t('tasks', 'Starts on') + '] MMM DD, YYYY';
+ 					} else {
+ 						return '[' + t('tasks', 'Started on') + '] MMM DD, YYYY';
+ 					}
+ 				}
+ 			}
+ 		});
 	  moment.locale('reminder', {
 		calendar: {
 		  lastDay: t('tasks', '[Remind me yesterday at ]HH:mm'),

--- a/js/app/controllers/detailscontroller.js
+++ b/js/app/controllers/detailscontroller.js
@@ -291,7 +291,7 @@ angular.module('Tasks').controller('DetailsController', [
 				};
 
  				this._$scope.isAllDayPossible = function(task) {
- 					return task.calendar.writable && (task.due || task.start);
+ 					return !angular.isUndefined(task) && task.calendar.writable && (task.due || task.start);
  				};
  				this._$scope.toggleAllDay = function(task) {
  					_tasksbusinesslayer.setAllDay(task, !task.allDay);

--- a/js/app/controllers/detailscontroller.js
+++ b/js/app/controllers/detailscontroller.js
@@ -290,6 +290,13 @@ angular.module('Tasks').controller('DetailsController', [
 					_tasksbusinesslayer.deleteDueDate(task);
 				};
 
+ 				this._$scope.isAllDayPossible = function(task) {
+ 					return task.calendar.writable && (task.due || task.start);
+ 				};
+ 				this._$scope.toggleAllDay = function(task) {
+ 					_tasksbusinesslayer.setAllDay(task, !task.allDay);
+ 				};
+
 				  this._$scope.setreminderday = function(date) {
 					return _tasksbusinesslayer.setReminderDate(_$scope.route.taskID, moment(date, 'MM/DD/YYYY'), 'day');
 				  };

--- a/js/app/filters/dateDetails.js
+++ b/js/app/filters/dateDetails.js
@@ -23,7 +23,7 @@ angular.module('Tasks').filter('dateDetails', function() {
 	'use strict';
 	return function(due) {
 		if (moment(due, "YYYYMMDDTHHmmss").isValid()) {
-			return moment(due, "YYYYMMDDTHHmmss").locale('details').calendar();
+			return moment(due, "YYYYMMDDTHHmmss").locale(due.isDate ? 'details_allday' : 'details').calendar();
 		} else {
 			return t('tasks', 'Set due date');
 		}

--- a/js/app/filters/startDetails.js
+++ b/js/app/filters/startDetails.js
@@ -23,7 +23,7 @@ angular.module('Tasks').filter('startDetails', function() {
 	'use strict';
 	return function(due) {
 		if (moment(due, "YYYYMMDDTHHmmss").isValid()) {
-			return moment(due, "YYYYMMDDTHHmmss").locale('start').calendar();
+			return moment(due, "YYYYMMDDTHHmmss").locale(due.isDate ? 'start_allday' : 'start').calendar();
 		} else {
 			return t('tasks', 'Set start date');
 		}

--- a/js/app/services/businesslayer/tasksbusinesslayer.js
+++ b/js/app/services/businesslayer/tasksbusinesslayer.js
@@ -217,6 +217,11 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				this.doUpdate(task);
 			};
 
+ 			TasksBusinessLayer.prototype.setAllDay = function(task, allDay) {
+ 				task.allDay = allDay;
+ 				this.doUpdate(task);
+ 			};
+ 
 			TasksBusinessLayer.prototype.initReminder = function(taskID) {
 				var p, task;
 				if (!this.checkReminderDate(taskID)) {

--- a/js/app/services/businesslayer/tasksbusinesslayer.js
+++ b/js/app/services/businesslayer/tasksbusinesslayer.js
@@ -144,6 +144,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				if (type === null) {
 					type = 'day';
 				}
+				var allDay = task.allDay;
 				var due = moment(task.due, "YYYY-MM-DDTHH:mm:ss");
 				if (type === 'day') {
 					if (moment(due).isValid()) {
@@ -163,6 +164,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 					return;
 				}
 				task.due = due.format('YYYY-MM-DDTHH:mm:ss');
+				task.due.isDate = allDay;
 				// this.checkReminderDate(task);
 				this.doUpdate(task);
 			};
@@ -187,6 +189,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				if (type === null) {
 					type = 'day';
 				}
+				var allDay = task.allDay;
 				var start = moment(task.start, "YYYY-MM-DDTHH:mm:ss");
 				if (type === 'day') {
 					if (moment(start).isValid()) {
@@ -204,6 +207,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 					return;
 				}
 				task.start = start.format('YYYY-MM-DDTHH:mm:ss');
+				task.start.isDate = allDay;
 				// this.checkReminderDate(taskID);
 				this.doUpdate(task);
 			};

--- a/js/app/services/models/vtodo.js
+++ b/js/app/services/models/vtodo.js
@@ -221,6 +221,28 @@ angular.module('Tasks').factory('VTodo', ['$filter', 'ICalFactory', 'RandomStrin
 			this.updateLastModified();
 			this.data = this.components.toString();
 		},
+ 		get allDay() {
+ 			var vtodos = this.components.getAllSubcomponents('vtodo');
+ 			var start = vtodos[0].getFirstPropertyValue('dtstart');
+ 			var due = vtodos[0].getFirstPropertyValue('due');
+ 			var d = due ? due : start;
+ 			return d!=null && d.isDate;
+ 		},
+ 		set allDay(allDay) {
+ 			var vtodos = this.components.getAllSubcomponents('vtodo');
+ 			var start = vtodos[0].getFirstPropertyValue('dtstart');
+ 			if(start) {
+ 				start.isDate = allDay;
+ 				vtodos[0].updatePropertyWithValue('dtstart', start);
+ 			}
+ 			var due = vtodos[0].getFirstPropertyValue('due');
+ 			if(due) {
+ 				due.isDate = allDay;
+ 				vtodos[0].updatePropertyWithValue('due', due);
+ 			}
+ 			this.updateLastModified();
+ 			this.data = this.components.toString();
+ 		},
 		get comments() {
 			return null;
 		},

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -505,7 +505,7 @@ angular.module('Tasks').controller('DetailsController', [
 				};
 
  				this._$scope.isAllDayPossible = function(task) {
- 					return task.calendar.writable && (task.due || task.start);
+ 					return !angular.isUndefined(task) && task.calendar.writable && (task.due || task.start);
  				};
  				this._$scope.toggleAllDay = function(task) {
  					_tasksbusinesslayer.setAllDay(task, !task.allDay);
@@ -2134,6 +2134,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				if (type === null) {
 					type = 'day';
 				}
+				var allDay = task.allDay;
 				var due = moment(task.due, "YYYY-MM-DDTHH:mm:ss");
 				if (type === 'day') {
 					if (moment(due).isValid()) {
@@ -2153,6 +2154,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 					return;
 				}
 				task.due = due.format('YYYY-MM-DDTHH:mm:ss');
+				task.due.isDate = allDay;
 				// this.checkReminderDate(task);
 				this.doUpdate(task);
 			};
@@ -2177,6 +2179,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				if (type === null) {
 					type = 'day';
 				}
+				var allDay = task.allDay;
 				var start = moment(task.start, "YYYY-MM-DDTHH:mm:ss");
 				if (type === 'day') {
 					if (moment(start).isValid()) {
@@ -2194,6 +2197,7 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 					return;
 				}
 				task.start = start.format('YYYY-MM-DDTHH:mm:ss');
+				task.start.isDate = allDay;
 				// this.checkReminderDate(taskID);
 				this.doUpdate(task);
 			};

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -68,6 +68,16 @@ angular.module('Tasks').run([
 				sameElse: '[' + t('tasks', 'Due on') + '] MMM DD, YYYY, HH:mm'
 			}
 		});
+ 		moment.locale('details_allday', {
+ 			calendar: {
+ 				lastDay: '[' + t('tasks', 'Due yesterday') + ']',
+ 				sameDay: '[' + t('tasks', 'Due today') + ']',
+ 				nextDay: '[' + t('tasks', 'Due tomorrow') + ']',
+ 				lastWeek: '[' + t('tasks', 'Due on') + '] MMM DD, YYYY',
+ 				nextWeek: '[' + t('tasks', 'Due on') + '] MMM DD, YYYY',
+ 				sameElse: '[' + t('tasks', 'Due on') + '] MMM DD, YYYY'
+ 			}
+ 		});
 		moment.locale('start', {
 			calendar: {
 				lastDay: '[' + t('tasks', 'Started yesterday') + '], HH:mm',
@@ -84,6 +94,22 @@ angular.module('Tasks').run([
 				}
 			}
 		});
+ 		moment.locale('start_allday', {
+ 			calendar: {
+ 				lastDay: '[' + t('tasks', 'Started yesterday') + ']',
+ 				sameDay: '[' + t('tasks', 'Starts today') + ']',
+ 				nextDay: '[' + t('tasks', 'Starts tomorrow') + ']',
+ 				lastWeek: '[' + t('tasks', 'Started on') + '] MMM DD, YYYY',
+ 				nextWeek: '[' + t('tasks', 'Starts on') + '] MMM DD, YYYY',
+ 				sameElse: function() {
+ 					if (this.diff(moment()) > 0) {
+ 						return '[' + t('tasks', 'Starts on') + '] MMM DD, YYYY';
+ 					} else {
+ 						return '[' + t('tasks', 'Started on') + '] MMM DD, YYYY';
+ 					}
+ 				}
+ 			}
+ 		});
 	  moment.locale('reminder', {
 		calendar: {
 		  lastDay: t('tasks', '[Remind me yesterday at ]HH:mm'),
@@ -477,6 +503,13 @@ angular.module('Tasks').controller('DetailsController', [
 				this._$scope.deleteDueDate = function(task) {
 					_tasksbusinesslayer.deleteDueDate(task);
 				};
+
+ 				this._$scope.isAllDayPossible = function(task) {
+ 					return task.calendar.writable && (task.due || task.start);
+ 				};
+ 				this._$scope.toggleAllDay = function(task) {
+ 					_tasksbusinesslayer.setAllDay(task, !task.allDay);
+ 				};
 
 				  this._$scope.setreminderday = function(date) {
 					return _tasksbusinesslayer.setReminderDate(_$scope.route.taskID, moment(date, 'MM/DD/YYYY'), 'day');
@@ -1644,7 +1677,7 @@ angular.module('Tasks').filter('dateDetails', function() {
 	'use strict';
 	return function(due) {
 		if (moment(due, "YYYYMMDDTHHmmss").isValid()) {
-			return moment(due, "YYYYMMDDTHHmmss").locale('details').calendar();
+			return moment(due, "YYYYMMDDTHHmmss").locale(due.isDate ? 'details_allday' : 'details').calendar();
 		} else {
 			return t('tasks', 'Set due date');
 		}
@@ -1783,7 +1816,7 @@ angular.module('Tasks').filter('startDetails', function() {
 	'use strict';
 	return function(due) {
 		if (moment(due, "YYYYMMDDTHHmmss").isValid()) {
-			return moment(due, "YYYYMMDDTHHmmss").locale('start').calendar();
+			return moment(due, "YYYYMMDDTHHmmss").locale(due.isDate ? 'start_allday' : 'start').calendar();
 		} else {
 			return t('tasks', 'Set start date');
 		}
@@ -2174,6 +2207,11 @@ angular.module('Tasks').factory('TasksBusinessLayer', [
 				this.doUpdate(task);
 			};
 
+ 			TasksBusinessLayer.prototype.setAllDay = function(task, allDay) {
+ 				task.allDay = allDay;
+ 				this.doUpdate(task);
+ 			};
+ 
 			TasksBusinessLayer.prototype.initReminder = function(taskID) {
 				var p, task;
 				if (!this.checkReminderDate(taskID)) {
@@ -4226,6 +4264,28 @@ angular.module('Tasks').factory('VTodo', ['$filter', 'ICalFactory', 'RandomStrin
 			this.updateLastModified();
 			this.data = this.components.toString();
 		},
+ 		get allDay() {
+ 			var vtodos = this.components.getAllSubcomponents('vtodo');
+ 			var start = vtodos[0].getFirstPropertyValue('dtstart');
+ 			var due = vtodos[0].getFirstPropertyValue('due');
+ 			var d = due ? due : start;
+ 			return d!=null && d.isDate;
+ 		},
+ 		set allDay(allDay) {
+ 			var vtodos = this.components.getAllSubcomponents('vtodo');
+ 			var start = vtodos[0].getFirstPropertyValue('dtstart');
+ 			if(start) {
+ 				start.isDate = allDay;
+ 				vtodos[0].updatePropertyWithValue('dtstart', start);
+ 			}
+ 			var due = vtodos[0].getFirstPropertyValue('due');
+ 			if(due) {
+ 				due.isDate = allDay;
+ 				vtodos[0].updatePropertyWithValue('due', due);
+ 			}
+ 			this.updateLastModified();
+ 			this.data = this.components.toString();
+ 		},
 		get comments() {
 			return null;
 		},

--- a/templates/part.details.php
+++ b/templates/part.details.php
@@ -49,7 +49,9 @@
             </div>
             <div class="section detail-all-day handler" ng-click="toggleAllDay(task)" ng-if="isAllDayPossible(task)">
                     <span class="icon detail-checkbox disabled" ng-class="{'detail-checked': task.allDay, 'disabled': !task.calendar.writable}"></span>
-                    <text><?php p($l->t('All day')); ?></text>
+                    <div class="section-title">
+                        <text><?php p($l->t('All day')); ?></text>
+                    </div>
             </div>
 
 <!--             <div class="section detail-reminder handler" ng-class="{'date':isDue(task.reminder.date), 'editing':route.parameter=='reminder'}" ng-click="editReminder($event, task)">

--- a/templates/part.details.php
+++ b/templates/part.details.php
@@ -29,7 +29,7 @@
                 <span class="icon detail-save handler end-edit"></span>
                 <div class="section-edit">
                     <input class="datepicker-input medium focus" type="text" key-value="" placeholder="dd.mm.yyyy" value="{{ task.start | dateTaskList }}" datepicker="start">
-                    <input class="timepicker-input medium focus handler" type="text" key-value="" placeholder="hh:mm" value="{{ task.start | timeTaskList }}" timepicker="start">
+                    <input class="timepicker-input medium focus handler" ng-hide="task.allDay" type="text" key-value="" placeholder="hh:mm" value="{{ task.start | timeTaskList }}" timepicker="start">
                 </div>
             </div>
             <div class="section detail-date handler" ng-class="{'date':isDue(task.due), 'editing':route.parameter=='duedate'}" ng-click="editDueDate($event, task)">
@@ -44,9 +44,14 @@
                 <span class="icon detail-save handler end-edit"></span>
                 <div class="section-edit">
     				<input class="datepicker-input medium focus" type="text" key-value="" placeholder="dd.mm.yyyy" value="{{ task.due | dateTaskList }}" datepicker="due">
-                    <input class="timepicker-input medium focus" type="text" key-value="" placeholder="hh:mm" value="{{ task.due | timeTaskList }}" timepicker="due">
+                    <input class="timepicker-input medium focus" ng-hide="task.allDay" type="text" key-value="" placeholder="hh:mm" value="{{ task.due | timeTaskList }}" timepicker="due">
                 </div>
             </div>
+            <div class="section detail-all-day handler" ng-click="toggleAllDay(task)" ng-if="isAllDayPossible(task)">
+                    <span class="icon detail-checkbox disabled" ng-class="{'detail-checked': task.allDay, 'disabled': !task.calendar.writable}"></span>
+                    <text><?php p($l->t('All day')); ?></text>
+            </div>
+
 <!--             <div class="section detail-reminder handler" ng-class="{'date':isDue(task.reminder.date), 'editing':route.parameter=='reminder'}" ng-click="editReminder($event, task)">
             	<span class="icon detail-reminder" ng-class="{'overdue':isOverDue(task.reminder.date)}"></span>
                 <span class="icon detail-remindertype" ng-click="changeReminderType(task)" ng-show="task.due || task.start"></span>


### PR DESCRIPTION
Fixes #18.

According to [RFC 5545](https://tools.ietf.org/html/rfc5545), `DTSTART` and `DUE` can be either of type `DATETIME` or `DATE`. Until now, this is not respected by the GUI which forces `DATETIME`. With this pull request, times and the time input field are hidden, if the type of `DTSTART` or `DUE` is `DATE`. Furthermore, a new checkbox allows to switch between `DATETIME` and `DATE`. Since according to RFC 5545, `DTSTART` and `DUE` must have the same type, this change applies to both fields, if set.

![oc-tasks-allday](https://cloud.githubusercontent.com/assets/6277619/18036468/50b39d52-6d6b-11e6-92f0-7ba9e44b56f6.png)

## Open issues
1. The checkbox is shown below of the due date in the details bar on the right side. Some designers have to approve, if the new checkbox is acceptable.
2. The label of the checkbox is `All day`. This string is new to the localization and have to be added to Transifex and translated to the other languages (e.g., German:`Ganztägig`).