### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/js/app/services/calendarservice.js
+++ b/js/app/services/calendarservice.js
@@ -123,7 +123,7 @@ angular.module('Tasks').service('CalendarService', ['DavClient', 'Calendar', fun
 
 				_this._getACLFromResponse(body);
 
-				var uri = body.href.substr(_this._CALENDAR_HOME.length).replace(/[^\w\-]+/g, '');
+				var uri = body.href.slice(_this._CALENDAR_HOME.length).replace(/[^\w\-]+/g, '');
 
 				var calendar = new Calendar(body.href, body.propStat[0].properties, uri);
 				calendars.push(calendar);
@@ -156,7 +156,7 @@ angular.module('Tasks').service('CalendarService', ['DavClient', 'Calendar', fun
 
 			_this._getACLFromResponse(body);
 
-			var uri = body.href.substr(_this._CALENDAR_HOME.length).replace(/[^\w\-]+/g, '');
+			var uri = body.href.slice(_this._CALENDAR_HOME.length).replace(/[^\w\-]+/g, '');
 
 			return new Calendar(body.href, body.propStat[0].properties, uri);
 		});
@@ -440,8 +440,8 @@ angular.module('Tasks').service('CalendarService', ['DavClient', 'Calendar', fun
 
 		while (this._isUriAlreadyTaken(uri)) {
 			var positionLastDash = uri.lastIndexOf('-');
-			var firstPart = uri.substr(0, positionLastDash);
-			var lastPart = uri.substr(positionLastDash + 1);
+			var firstPart = uri.slice(0, positionLastDash !== -1 ? positionLastDash : 0);
+			var lastPart = uri.slice(positionLastDash + 1);
 
 			if (lastPart.match(/^\d+$/)) {
 				lastPart = parseInt(lastPart);

--- a/js/app/services/models/calendar.js
+++ b/js/app/services/models/calendar.js
@@ -32,7 +32,7 @@ angular.module('Tasks').factory('Calendar', ['$rootScope', '$filter', '$window',
 		props.color = props['{http://apple.com/ns/ical/}calendar-color'];
 		if (typeof props.color !== 'undefined') {
 			if (props.color.length === 9) {
-				props.color = props.color.substr(0,7);
+				props.color = props.color.slice(0,7);
 			}
 		} else {
 			props.color = '#1d2d44';
@@ -126,14 +126,14 @@ angular.module('Tasks').factory('Calendar', ['$rootScope', '$filter', '$window',
 
 				if (href.startsWith('principal:principals/users/')) {
 					this._properties.sharedWith.users.push({
-						id: href.substr(27),
-						displayname: href.substr(27),
+						id: href.slice(27),
+						displayname: href.slice(27),
 						writable: readWrite
 					});
 				} else if (href.startsWith('principal:principals/groups/')) {
 					this._properties.sharedWith.groups.push({
-						id: href.substr(28),
-						displayname: href.substr(28),
+						id: href.slice(28),
+						displayname: href.slice(28),
 						writable: readWrite
 					});
 				}
@@ -144,7 +144,7 @@ angular.module('Tasks').factory('Calendar', ['$rootScope', '$filter', '$window',
 		if (typeof owner !== 'undefined' && owner.length !== 0) {
 			owner = owner[0].textContent.slice(0, -1);
 			if (owner.startsWith('/remote.php/dav/principals/users/')) {
-				this._properties.owner = owner.substr(33);
+				this._properties.owner = owner.slice(33);
 			}
 		}
 
@@ -222,9 +222,9 @@ angular.module('Tasks').factory('Calendar', ['$rootScope', '$filter', '$window',
 					c = color.match(regex)[1];
 					if (c) {
 						return this._generateTextColor(
-							parseInt(c.substr(0,2),16),
-							parseInt(c.substr(2,2),16),
-							parseInt(c.substr(4,2),16)
+							parseInt(c.slice(0,2),16),
+							parseInt(c.slice(2,4),16),
+							parseInt(c.slice(4,6),16)
 						);
 					}
 					return fallbackColor;

--- a/js/app/services/randomstringservice.js
+++ b/js/app/services/randomstringservice.js
@@ -25,7 +25,7 @@ angular.module('Tasks').factory('RandomStringService', function () {
 
 	return {
 		generate: function() {
-			return Math.random().toString(36).substr(2);
+			return Math.random().toString(36).slice(2);
 		}
 	};
 });

--- a/js/app/services/vtodoservice.js
+++ b/js/app/services/vtodoservice.js
@@ -117,7 +117,7 @@ angular.module('Tasks').service('VTodoService', ['DavClient', 'RandomStringServi
 				var object = response.body[i];
 				var properties = object.propStat[0].properties;
 
-				var uri = object.href.substr(object.href.lastIndexOf('/') + 1);
+				var uri = object.href.slice(object.href.lastIndexOf('/') + 1);
 
 				var vTodo = {
 					calendar: calendar,


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.